### PR TITLE
Added an alias of onRefreshComplete called stopRefreshing

### DIFF
--- a/library/src/main/java/com/handmark/pulltorefresh/library/IPullToRefresh.java
+++ b/library/src/main/java/com/handmark/pulltorefresh/library/IPullToRefresh.java
@@ -140,6 +140,13 @@ public interface IPullToRefresh<T extends View> {
 	 */
 	public boolean isRefreshing();
 
+    /**
+     * Stops the current refreshing view when the user needs to stop.
+     * This method is only an alias to onRefreshComplete.
+     *
+     * */
+    public void stopRefreshing();
+
 	/**
 	 * Returns whether the widget has enabled scrolling on the Refreshable View
 	 * while refreshing.

--- a/library/src/main/java/com/handmark/pulltorefresh/library/PullToRefreshBase.java
+++ b/library/src/main/java/com/handmark/pulltorefresh/library/PullToRefreshBase.java
@@ -306,6 +306,11 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout imp
 		return mState == State.REFRESHING || mState == State.MANUAL_REFRESHING;
 	}
 
+    @Override
+    public final void stopRefreshing() {
+        onRefreshComplete();
+    }
+
 	@Override
 	public final boolean isScrollingWhileRefreshingEnabled() {
 		return mScrollingWhileRefreshingEnabled;


### PR DESCRIPTION
This is because when an user wants to stop refreshing programacally, he could not understand what is the method to complete this action. onRefreshComplete method check the var ifRefreshing.
